### PR TITLE
Fix owner wealth calculation to avoid double-counting down payment

### DIFF
--- a/index.html
+++ b/index.html
@@ -442,7 +442,7 @@
         ownerCum.push(baseOwnerCashOut+extraCapex);
         ownerCumWithOpp.push(baseOwnerCashOut+extraCapex+foregoneDown+foregoneCapex);
 
-        const totalExpenses=down+notaryCost+paid.totalInterest+recCum[y-1]+extraCapex;
+        const totalExpenses=notaryCost+paid.totalInterest+recCum[y-1]+extraCapex;
         ownerWealth.push(salePrice-totalExpenses-paid.remaining);
       }
 


### PR DESCRIPTION
## Summary
- remove the down payment from the owner wealth expense calculation to avoid subtracting it twice

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dae6964a0c8324b502d1f909b4021b